### PR TITLE
Make META file spec-compliant

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,7 +1,8 @@
 {
+    "perl"          : "6.c",
     "name"          : "AttrX::PrivateAccessor",
     "version"       : "0.0.1",
-    "author"        : "github:pierre-vigier",
+    "authors"       : [ "github:pierre-vigier" ],
     "description"   : "Providing private accessors for private attributes",
     "depends"       : [ ],
     "provides" : {


### PR DESCRIPTION
Also, (not sure how to do it via GitHub web interface), but the file should be named `META6.json`. `META.info` still works, but that's an old format.

You may find http://modules.perl6.org/repo/Test::META useful for keeping your META compliant.
